### PR TITLE
fix: fixed depcontainer shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ import { getApp } from './app';
 let depContainer: DependencyContainer | undefined;
 
 void getApp()
-  .then(([app, depContainer]) => {
+  .then(([app, container]) => {
+    depContainer = container;
+    
     const logger = depContainer.resolve<Logger>(SERVICES.LOGGER);
     const config = depContainer.resolve<ConfigType>(SERVICES.CONFIG);
     const port = config.get('server.port');


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further information:
Something I think I've missed in the PR. 
Because  `.then(([app, depContainer])`
The `depContainer` reference in `.catch` is not being initialized and will always be undefined. On server- shutdown, the shutdown sequence won't initiate 
